### PR TITLE
Fixed MANIFEST for package distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
 include libcnml/cnml.dtd
 include CHANGES.rst README.md LICENSE.txt
-recursive-include libcnml/tests/data *cnml
-exclude MANIFEST.in
+recursive-include libcnml/tests *.py
+recursive-include libcnml/tests/data *.cnml


### PR DESCRIPTION
Missing tests and the MANIFESt file itself caused problems when packaging for linux distributions
like Fedora or Debian.
This patch will allow distributions to use the source published on pypi without patches.
